### PR TITLE
Add index route

### DIFF
--- a/main.py
+++ b/main.py
@@ -4,6 +4,12 @@ import kml_utils  # existing helper module
 
 app = FastAPI(title="Vision\u00a0Backend API", version="1.0.0")
 
+
+@app.get("/")
+async def index():
+    """Simple index redirect hinting at docs."""
+    return {"message": "See /docs for API documentation"}
+
 app.add_middleware(
     CORSMiddleware,
     allow_origins=["*"],      # TODO: tighten in prod

--- a/tests/test_root_route.py
+++ b/tests/test_root_route.py
@@ -1,0 +1,8 @@
+from fastapi.testclient import TestClient
+from main import app
+
+def test_root_endpoint():
+    client = TestClient(app)
+    resp = client.get('/')
+    assert resp.status_code == 200
+    assert resp.json() == {"message": "See /docs for API documentation"}


### PR DESCRIPTION
## Summary
- expose a simple root endpoint and test it

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6881ff651ea08327a2670787d5abd8e5